### PR TITLE
Add timed roslaunch

### DIFF
--- a/third_robot.rosinstall
+++ b/third_robot.rosinstall
@@ -14,3 +14,7 @@
     local-name: hokuyo3d
     uri: https://github.com/at-wat/hokuyo3d.git
     version: master
+- git:
+    local-name: timed_roslaunch
+    uri: https://github.com/MoriKen254/timed_roslaunch.git
+    version: master


### PR DESCRIPTION
`third_robot_2dnav_gazebo` で使っている機能を追加しています．third_robot_pkgに依存しない汎用的な機能なので，こちらに入れています．

> 補足．laser senser merger について，gazeboでセンサプラグインが完全に起動してから立ち上げないと機能しないという問題がありました．gazeboが完全起動するには少々時間がかかるので，時間差でlaunchを叩くというuglyな解決をしています…．