### PR TITLE
Fix target object approach

### DIFF
--- a/waypoint_navigator/src/waypoint_navigator.cpp
+++ b/waypoint_navigator/src/waypoint_navigator.cpp
@@ -326,6 +326,7 @@ public:
       answers[1].position.y = target_position.position.y - (C*tolerance)/sqrt(1+pow(C, 2.0));
     }
     for (size_t i = 0; i < 2; ++i) {
+      answers[i].orientation = target_position.orientation;
       distances[i] = this->calculateDistance(robot_position, answers[i]);
     }
     if (distances[0] < distances[1]) {


### PR DESCRIPTION
探索対象にゴールを設定する際に直接ゴールに設定すると障害物上にゴールを設定することになり、上手くプランニングが出来ない。
そこで、ロボットの現在位置と探索対象を結ぶ直線と探索対象を中心とした円の交点座標を計算し、ロボットに近い方の交点をゴールに設定するように変更。