### PR TITLE
add kinect point cloud downsampler

### DIFF
--- a/point_cloud_reducer/CMakeLists.txt
+++ b/point_cloud_reducer/CMakeLists.txt
@@ -1,0 +1,45 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(point_cloud_reducer)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  tf
+  tf_conversions
+  cmake_modules
+  std_msgs
+  sensor_msgs
+  pcl_ros
+  pcl_conversions
+  cmake_modules
+)
+
+## System dependencies are found with CMake's conventions
+find_package(Boost REQUIRED system filesystem date_time thread)
+find_package(PCL REQUIRED QUIET COMPONENTS common)
+find_package(Eigen REQUIRED)
+
+
+catkin_package(
+  CATKIN_DEPENDS roscpp sensor_msgs std_msgs pcl_ros pcl_msgs tf tf_conversions
+  )
+
+include_directories(SYSTEM ${Boost_INCLUDE_DIR} ${EIGEN_INCLUDE_DIRS})
+include_directories(
+  include
+  ${catkin_INCLUDE_DIRS}
+  )
+
+include_directories(include ${catkin_INCLUDE_DIRS} ${PCL_COMMON_INCLUDE_DIRS} ${Eigen_INCLUDE_DIRS})
+
+add_executable(
+  kinect_downsampler_node
+  src/kinect_downsampler.cpp
+  src/kinect_downsampler_node.cpp
+  )
+
+target_link_libraries(kinect_downsampler_node
+  ${catkin_LIBRARIES}
+)

--- a/point_cloud_reducer/include/kinect_downsampler.h
+++ b/point_cloud_reducer/include/kinect_downsampler.h
@@ -1,0 +1,43 @@
+#ifndef KINECT_DOWNSAMPLER_H
+#define KINECT_DOWNSAMPLER_H
+
+#include <iostream>
+#include <sstream>
+#include <fstream>
+#include <string>
+
+#include <ros/ros.h>
+#include <std_msgs/Bool.h>
+#include <std_msgs/Float32.h>
+#include <sensor_msgs/PointCloud2.h>
+
+#include <tf/transform_broadcaster.h>
+#include <tf/transform_datatypes.h>
+
+#include <pcl/io/io.h>
+#include <pcl/io/pcd_io.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+#include <pcl/registration/ndt.h>
+#include <pcl/filters/approximate_voxel_grid.h>
+#include <pcl/filters/voxel_grid.h>
+
+class KinectV2Downsampler
+{
+public:
+  KinectV2Downsampler(ros::NodeHandle nh, ros::NodeHandle n);
+  void resizeCallback(const sensor_msgs::PointCloud2::ConstPtr& source_pc);
+  void run();
+private:
+  ros::NodeHandle nh_;
+  ros::Rate rate_;
+  std::string frame_id_;
+  ros::Publisher resized_pc_pub_;
+  ros::Subscriber source_pc_sub_;
+
+  double leaf_size_x_;
+  double leaf_size_y_;
+  double leaf_size_z_;
+};
+
+#endif /* KINECT_DOWNSAMPLER_H */

--- a/point_cloud_reducer/launch/kinect_downsampler.launch
+++ b/point_cloud_reducer/launch/kinect_downsampler.launch
@@ -1,0 +1,11 @@
+<launch>
+  <node name="kinect_downsampler" pkg="point_cloud_reducer" type="kinect_downsampler_node">
+    <param name="loop_rate" value="10" />
+    <param name="resized_pc_topic_name" value="/hokuyo3d/hokuyo_cloud2" />
+    <param name="source_pc_topic_name" value="/camera/depth/points" />
+    <param name="resized_pc_frame_id" value="/front_top_3durg_rgbd_optical_frame" />
+    <param name="leaf_size_x" value="0.2" />
+    <param name="leaf_size_y" value="0.2" />
+    <param name="leaf_size_z" value="0.2" />
+  </node>
+</launch>

--- a/point_cloud_reducer/package.xml
+++ b/point_cloud_reducer/package.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0"?>
+<package>
+  <name>point_cloud_reducer</name>
+  <version>0.0.0</version>
+  <description>The point_cloud_reducer package</description>
+
+  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
+  <!-- Example:  -->
+  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
+  <maintainer email="yuta@todo.todo">yuta</maintainer>
+
+
+  <!-- One license tag required, multiple allowed, one license per tag -->
+  <!-- Commonly used license strings: -->
+  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
+  <license>TODO</license>
+
+
+  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
+  <!-- Optional attribute type can be: website, bugtracker, or repository -->
+  <!-- Example: -->
+  <!-- <url type="website">http://wiki.ros.org/point_cloud_reducer</url> -->
+
+
+  <!-- Author tags are optional, mutiple are allowed, one per tag -->
+  <!-- Authors do not have to be maintianers, but could be -->
+  <!-- Example: -->
+  <!-- <author email="jane.doe@example.com">Jane Doe</author> -->
+
+
+  <!-- The *_depend tags are used to specify dependencies -->
+  <!-- Dependencies can be catkin packages or system dependencies -->
+  <!-- Examples: -->
+  <!-- Use build_depend for packages you need at compile time: -->
+  <!--   <build_depend>message_generation</build_depend> -->
+  <!-- Use buildtool_depend for build tool packages: -->
+  <!--   <buildtool_depend>catkin</buildtool_depend> -->
+  <!-- Use run_depend for packages you need at runtime: -->
+  <!--   <run_depend>message_runtime</run_depend> -->
+  <!-- Use test_depend for packages you need only for testing: -->
+  <!--   <test_depend>gtest</test_depend> -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>std_msgs</build_depend>
+  <build_depend>pcl_ros</build_depend>
+  <build_depend>pcl_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <build_depend>tf_conversions</build_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>std_msgs</run_depend>
+  <run_depend>pcl_ros</run_depend>
+  <run_depend>pcl_msgs</run_depend>
+  <run_depend>tf</run_depend>
+  <run_depend>tf_conversions</run_depend>
+  <!-- The export tag contains other, unspecified, tags -->
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+
+  </export>
+</package>

--- a/point_cloud_reducer/src/kinect_downsampler.cpp
+++ b/point_cloud_reducer/src/kinect_downsampler.cpp
@@ -1,0 +1,41 @@
+#include <kinect_downsampler.h>
+
+KinectV2Downsampler::KinectV2Downsampler(ros::NodeHandle nh, ros::NodeHandle n)
+  : nh_(nh), rate_(n.param("loop_rate", 10)),
+    frame_id_(n.param<std::string>("resized_pc_frame_id", "/resized_pc_frame"))
+{
+  leaf_size_x_ = n.param("leaf_size_x", 0.3);
+  leaf_size_y_ = n.param("leaf_size_y", 0.3);
+  leaf_size_z_ = n.param("leaf_size_z", 0.3);
+  
+  source_pc_sub_ = nh_.subscribe(n.param<std::string>("source_pc_topic_name", "/source_pointcloud"), 1, &KinectV2Downsampler::resizeCallback, this);
+  resized_pc_pub_ = nh_.advertise<sensor_msgs::PointCloud2>(n.param<std::string>("resized_pc_topic_name", "/resized_pointcloud"), 1);
+}
+
+void KinectV2Downsampler::resizeCallback(const sensor_msgs::PointCloud2::ConstPtr& source_pc)
+{
+  pcl::PointCloud<pcl::PointXYZ> pcl_source;
+  pcl::fromROSMsg(*source_pc, pcl_source);
+  pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_source_ptr(new pcl::PointCloud<pcl::PointXYZ>(pcl_source));
+  pcl::PointCloud<pcl::PointXYZ>::Ptr resized_pc_ptr (new pcl::PointCloud<pcl::PointXYZ>);
+
+  pcl::ApproximateVoxelGrid<pcl::PointXYZ> approximate_voxel_filter;
+  approximate_voxel_filter.setLeafSize (leaf_size_x_, leaf_size_y_, leaf_size_z_);
+  approximate_voxel_filter.setInputCloud (pcl_source_ptr);
+  approximate_voxel_filter.filter (*resized_pc_ptr);
+
+  sensor_msgs::PointCloud2 resized_pc;
+  pcl::toROSMsg(*resized_pc_ptr, resized_pc);
+  resized_pc.header.stamp = ros::Time::now();
+  resized_pc.header.frame_id = frame_id_;
+  resized_pc_pub_.publish(resized_pc);
+}
+
+void KinectV2Downsampler::run()
+{
+  while(nh_.ok())
+    {
+      ros::spinOnce();
+      rate_.sleep();
+    }
+}

--- a/point_cloud_reducer/src/kinect_downsampler_node.cpp
+++ b/point_cloud_reducer/src/kinect_downsampler_node.cpp
@@ -1,0 +1,13 @@
+#include <kinect_downsampler.h>
+
+int main(int argc, char *argv[])
+{
+  ros::init(argc, argv, "Kinect Dowmsampler Node");
+  ros::NodeHandle nh;
+  ros::NodeHandle n("~");
+
+  KinectV2Downsampler sampler(nh, n);
+  sampler.run();
+  
+  return 0;
+}


### PR DESCRIPTION
gazebo上でhokuyo3dを再現するkinectの点群が多すぎてdetectorのループが遅くて認識出来ないので点群を減らすノードを追加